### PR TITLE
Revert "Bump rack from 2.0.5 to 2.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.0)
     puma (3.9.1)
-    rack (2.0.8)
+    rack (2.0.5)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)


### PR DESCRIPTION
Reverts b-artem/bookstore_dry_rb#12